### PR TITLE
feat: separate maste's and user's lobby pages, add notifications, sma…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
       <div>
         <Header />
       </div>
-      <SnackbarProvider maxSnack={3} autoHideDuration={2000}>
+      <SnackbarProvider maxSnack={3} autoHideDuration={3000} preventDuplicate>
         <SocketProvider>
           <AppProvider>
             <Switch>

--- a/src/Components/Connect-dialog/Connect-dialog.scss
+++ b/src/Components/Connect-dialog/Connect-dialog.scss
@@ -75,10 +75,17 @@
 
     .errors-wrapper{
         margin: 20px 10px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
 
         .error-text{
             color: red;
             font-weight: 500;
+        }
+        
+        .loading_position {
+            margin-bottom: 35px;
         }
     }    
 }

--- a/src/Components/Connect-dialog/Connect-dialog.tsx
+++ b/src/Components/Connect-dialog/Connect-dialog.tsx
@@ -3,6 +3,7 @@ import './connect-dialog.scss';
 import {
   Avatar,
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -34,8 +35,10 @@ const ConnectDialog: FC<IProps> = ({ roomId, createMode }) => {
   const [selectedFile, setSelectedFile] = useState<File | undefined>(undefined);
   const [imgUrl, setUrl] = useState('');
   const [isNameDirty, setNameDirty] = useState(false);
-  const socket = useContext(SocketContext);
+  const [isImgLoading, setLoading] = useState(false);
+
   const history = useHistory();
+  const socket = useContext(SocketContext);
   const { enqueueSnackbar } = useSnackbar();
 
   const handleSubmit = () => {
@@ -54,7 +57,7 @@ const ConnectDialog: FC<IProps> = ({ roomId, createMode }) => {
     } else {
       socket?.emit(
         'login',
-        { name, lastName, jobPosition, isObserver, imgUrl },
+        { name, lastName, position: jobPosition, observer: isObserver, imgUrl },
         roomId,
         (error: string) => {
           if (error) {
@@ -74,7 +77,10 @@ const ConnectDialog: FC<IProps> = ({ roomId, createMode }) => {
       setOpen(true);
     } else {
       socket?.emit('checkRoom', roomId, (isMatched: boolean) => {
-        isMatched ? setOpen(true) : setOpen(false);
+        console.log(isMatched);
+        isMatched
+          ? setOpen(true)
+          : enqueueSnackbar(`Error: Wrong room ID!`, { variant: 'error' });
       });
     }
   };
@@ -91,8 +97,10 @@ const ConnectDialog: FC<IProps> = ({ roomId, createMode }) => {
   };
 
   const setAvatar = async () => {
+    setLoading(true);
     let url = await uploadAvatar(selectedFile);
     setUrl(url);
+    setLoading(false);
   };
 
   return (
@@ -191,14 +199,21 @@ const ConnectDialog: FC<IProps> = ({ roomId, createMode }) => {
               </Avatar>
             </div>
             <div className="errors-wrapper">
-              {isNameDirty && !name && (
+              {isNameDirty && !name ? (
                 <span className="error-text">Enter your name</span>
+              ) : (
+                <div></div>
               )}
+              {isImgLoading && <CircularProgress className="loading_position" />}
             </div>
           </div>
         </DialogContent>
         <DialogActions>
-          <Button variant="contained" onClick={handleSubmit} color="primary">
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            color="primary"
+            disabled={!name}>
             Confirm
           </Button>
           <Button onClick={handleClose} color="primary">

--- a/src/Components/kick-player-dialog/kick-dialog.tsx
+++ b/src/Components/kick-player-dialog/kick-dialog.tsx
@@ -7,7 +7,7 @@ import CustomDialog from '../dialog';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
   target: string;
-  playerId: number;
+  playerId: string;
 }
 
 const KickDialog: FC<IProps> = ({ target, playerId }) => {

--- a/src/Components/player-card/player-card.tsx
+++ b/src/Components/player-card/player-card.tsx
@@ -1,8 +1,9 @@
 import './player-card.scss';
 
 import { Avatar } from '@material-ui/core';
-import React, { FC } from 'react';
+import React, { FC, useContext } from 'react';
 
+import { SocketContext } from '../../content/socket';
 import { TPlayer } from '../../data/game';
 import { getCapitalLetters } from '../../utils/formatters';
 import KickDialog from '../kick-player-dialog';
@@ -13,17 +14,22 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const PlayerCard: FC<IProps> = ({ player }) => {
   const { name, lastName, imgUrl, playerId, position, master } = player;
+  const socket = useContext(SocketContext);
+  const isSelf = playerId !== socket?.id;
+
   return (
     <div role="none" className="player-card_container">
       <Avatar alt={`${name} ${lastName}`} src={imgUrl} className="avatar">
         {!imgUrl ? (name ? getCapitalLetters(name, lastName) : 'NN') : ''}
       </Avatar>
       <div className="player-info_container">
-        <span className={!master ? 'not-you_text' : 'its-you_text'}>{`IT'S YOU`}</span>
+        <span className={isSelf ? 'not-you_text' : 'its-you_text'}>{`IT'S YOU`}</span>
         <span className="player-name_text">{`${name} ${lastName}`}</span>
         <span className="player-position_text">{position}</span>
       </div>
-      {!master && <KickDialog target={`${name} ${lastName}`} playerId={playerId} />}
+      {!master && isSelf && (
+        <KickDialog target={`${name} ${lastName}`} playerId={playerId} />
+      )}
     </div>
   );
 };

--- a/src/Pages/Lobby-page/Lobby-page.tsx
+++ b/src/Pages/Lobby-page/Lobby-page.tsx
@@ -25,8 +25,9 @@ import IssueAdd from '../../Components/issue-add';
 import PlayerCard from '../../Components/player-card';
 import { TitleAdd1, TitleAdd2, TitleMain } from '../../Components/titles';
 import { AppContext } from '../../content/app-state';
+import { SocketContext } from '../../content/socket';
 import { deck2 } from '../../data/deck';
-import { issueMockData, playersMockData } from '../../data/game';
+import { TPlayer } from '../../data/game';
 
 const LobbyPage: FunctionComponent<HTMLAttributes<HTMLDivElement>> = () => {
   const startGame = () => {
@@ -35,7 +36,9 @@ const LobbyPage: FunctionComponent<HTMLAttributes<HTMLDivElement>> = () => {
   const cancelGame = () => {
     console.log('cancelGame');
   };
-
+  const exitGame = () => {
+    console.log('exitGame');
+  };
   const copyUrlLobby = (copyText: string | undefined) => {
     if (copyText) {
       navigator.clipboard.writeText(copyText);
@@ -53,12 +56,19 @@ const LobbyPage: FunctionComponent<HTMLAttributes<HTMLDivElement>> = () => {
   const [scoreTypeShort, setScoreTypeShort] = useState('SP');
   const [isScoreTypeShortError, setIsScoreTypeShortError] = useState(false);
   const [roundTime, setRoundTime] = useState('00:01:30');
+  const [isMaster, setMaster] = useState(false);
 
   const appState = useContext(AppContext);
+  const socket = useContext(SocketContext);
 
   useEffect(() => {
     console.log(appState?.users);
     console.log(appState?.issues);
+    if (appState?.users.length) {
+      const id = socket?.id;
+      const user = appState?.users.find((user) => user.playerId === id);
+      setMaster(user?.master as boolean);
+    }
     if (appState?.users.length) setCopyText(appState?.users[0].playerId);
   }, [appState?.users, appState?.issues]);
 
@@ -93,181 +103,207 @@ const LobbyPage: FunctionComponent<HTMLAttributes<HTMLDivElement>> = () => {
         <Box className="start-game section" component="section">
           <TitleAdd1 className="label-scram-master text-center">Scram master:</TitleAdd1>
           <Box className="card-master mb-20">
-            <PlayerCard player={playersMockData[0]} key={playersMockData[0].playerId} />
-          </Box>
-          <Box className="link-to-lobby">
-            <TitleAdd1 className="label-link-to-lobby">Lobby ID:</TitleAdd1>
-            <Box className="copy-to-lobby">
-              <TextField
-                disabled
-                className="input-link-to-label"
-                id="outlined-helperText"
-                value={copyText}
-                variant="outlined"
-                InputProps={{
-                  readOnly: true,
-                }}
-                onChange={(e) => {
-                  setCopyText(e.target.value);
-                  setCopyTextBtn('Copy');
-                }}
+            {appState?.users.length && (
+              <PlayerCard
+                player={appState?.users[0] as TPlayer}
+                key={appState?.users[0].playerId}
               />
+            )}
+          </Box>
+          {isMaster ? (
+            <>
+              <Box className="link-to-lobby">
+                <TitleAdd1 className="label-link-to-lobby">Lobby ID:</TitleAdd1>
+                <Box className="copy-to-lobby">
+                  <TextField
+                    disabled
+                    className="input-link-to-label"
+                    id="outlined-helperText"
+                    value={copyText}
+                    variant="outlined"
+                    InputProps={{
+                      readOnly: true,
+                    }}
+                    onChange={(e) => {
+                      setCopyText(e.target.value);
+                      setCopyTextBtn('Copy');
+                    }}
+                  />
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={() => copyUrlLobby(copyText)}>
+                    {copyTextBtn}
+                  </Button>
+                </Box>
+              </Box>
+              <Box className="buttons-game mt-20 mb-20">
+                <Button
+                  className="p-10"
+                  variant="contained"
+                  color="primary"
+                  onClick={() => startGame()}>
+                  Start Game
+                </Button>
+                <Button
+                  className="p-10"
+                  variant="outlined"
+                  color="primary"
+                  onClick={() => cancelGame()}>
+                  Cancel game
+                </Button>
+              </Box>
+            </>
+          ) : (
+            <Box className="buttons-game mt-20 mb-20">
+              <div></div>
               <Button
-                variant="contained"
+                className="p-10"
+                variant="outlined"
                 color="primary"
-                onClick={() => copyUrlLobby(copyText)}>
-                {copyTextBtn}
+                onClick={() => exitGame()}>
+                Exit
               </Button>
             </Box>
-          </Box>
-          <Box className="buttons-game mt-20 mb-20">
-            <Button
-              className="p-10"
-              variant="contained"
-              color="primary"
-              onClick={() => startGame()}>
-              Start Game
-            </Button>
-            <Button
-              className="p-10"
-              variant="outlined"
-              color="primary"
-              onClick={() => cancelGame()}>
-              Cancel game
-            </Button>
-          </Box>
+          )}
         </Box>
 
         {/******************** Members Section ********************/}
         <Box className="members section" component="section">
           <TitleAdd1 className="label-members text-center">Members:</TitleAdd1>
           <Box className="cards-wrapper mb-20">
-            {playersMockData
-              .filter((e) => !e.master)
-              .map((el) => (
-                <PlayerCard player={el} key={el.playerId} />
-              ))}
+            {appState?.users.length &&
+              appState?.users
+                .filter((e) => !e.master)
+                .map((el) => <PlayerCard player={el} key={el.playerId} />)}
           </Box>
         </Box>
-
         {/******************** Issues Section ********************/}
-        <Box className="issues section" component="section">
-          <TitleAdd1 className="label-issues text-center">Issues:</TitleAdd1>
-          <Box className="cards-wrapper mb-20">
-            <Issue issue={issueMockData[0]} isLobby={true} />
-            <Issue issue={issueMockData[1]} isLobby={true} />
-            <Issue issue={issueMockData[2]} isLobby={true} />
-            {appState?.issues &&
-              appState?.issues.map((el) => (
-                <Issue issue={el} isLobby={true} key={el.issueID} />
-              ))}
-            <IssueAdd />
+        {isMaster && (
+          <Box className="issues section" component="section">
+            <TitleAdd1 className="label-issues text-center">Issues:</TitleAdd1>
+            <Box className="cards-wrapper mb-20">
+              {/* <Issue issue={issueMockData[0]} isLobby={true} />
+              <Issue issue={issueMockData[1]} isLobby={true} />
+              <Issue issue={issueMockData[2]} isLobby={true} /> */}
+              {appState?.issues &&
+                appState?.issues.map((el) => (
+                  <Issue issue={el} isLobby={true} key={el.issueID} />
+                ))}
+              <IssueAdd />
+            </Box>
           </Box>
-        </Box>
+        )}
 
         {/******************** Setting Section ********************/}
-        <Container className="setting section" component="section">
-          <TitleAdd1 className="setting-issues text-center">Game settings:</TitleAdd1>
-          <Grid className="setting-grid" container spacing={3}>
-            <Grid item xs={8}>
-              <TitleAdd2>Scram master as player:</TitleAdd2>
-            </Grid>
-            <Grid item xs={1}>
-              <Switch
-                checked={isMasterAsPlayer}
-                color="primary"
-                name="masterAsPlayer"
-                onChange={() => setIsMasterAsPlayer(!isMasterAsPlayer)}
-                inputProps={{ 'aria-label': 'primary checkbox' }}
-              />
-            </Grid>
-            <Grid item xs={8}>
-              <TitleAdd2>Changing card in round end:</TitleAdd2>
-            </Grid>
-            <Grid item xs={1}>
-              <Switch
-                checked={isCardRound}
-                color="primary"
-                name="cardRound"
-                onChange={() => setIsCardRound(!isCardRound)}
-                inputProps={{ 'aria-label': 'primary checkbox' }}
-              />
-            </Grid>
-            <Grid item xs={8}>
-              <TitleAdd2>Is timer needed:</TitleAdd2>
-            </Grid>
-            <Grid item xs={1}>
-              <Switch
-                checked={isTimerNeed}
-                color="primary"
-                name="timerNeed"
-                onChange={() => setIsTimerNeed(!isTimerNeed)}
-                inputProps={{ 'aria-label': 'primary checkbox' }}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TitleAdd2>Score type:</TitleAdd2>
-            </Grid>
-            <Grid item xs={2}>
-              <TextField
-                error={isScoreTypeError}
-                id="setting-scrore-type"
-                variant="outlined"
-                defaultValue={scoreType}
-                onChange={(e) => handleChangeScoreType(e.target.value)}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TitleAdd2>Score type (Short):</TitleAdd2>
-            </Grid>
-            <Grid item xs={2}>
-              <TextField
-                error={isScoreTypeShortError}
-                id="setting-scrore-type"
-                variant="outlined"
-                defaultValue={scoreTypeShort}
-                onChange={(e) => handleChangeScoreTypeShort(e.target.value)}
-              />
-            </Grid>
-          </Grid>
-          <Collapse in={isTimerNeed} timeout={1000}>
-            <Grid className="setting-grid mt-10" container spacing={3}>
-              <Grid item xs={10}>
-                <TitleAdd2>Round time:</TitleAdd2>
+        {isMaster && (
+          <Container className="setting section" component="section">
+            <TitleAdd1 className="setting-issues text-center">Game settings:</TitleAdd1>
+            <Grid className="setting-grid" container spacing={3}>
+              <Grid item xs={8}>
+                <TitleAdd2>Scram master as player:</TitleAdd2>
+              </Grid>
+              <Grid item xs={1}>
+                <Switch
+                  checked={isMasterAsPlayer}
+                  color="primary"
+                  name="masterAsPlayer"
+                  onChange={() => setIsMasterAsPlayer(!isMasterAsPlayer)}
+                  inputProps={{ 'aria-label': 'primary checkbox' }}
+                />
+              </Grid>
+              <Grid item xs={8}>
+                <TitleAdd2>Changing card in round end:</TitleAdd2>
+              </Grid>
+              <Grid item xs={1}>
+                <Switch
+                  checked={isCardRound}
+                  color="primary"
+                  name="cardRound"
+                  onChange={() => setIsCardRound(!isCardRound)}
+                  inputProps={{ 'aria-label': 'primary checkbox' }}
+                />
+              </Grid>
+              <Grid item xs={8}>
+                <TitleAdd2>Is timer needed:</TitleAdd2>
+              </Grid>
+              <Grid item xs={1}>
+                <Switch
+                  checked={isTimerNeed}
+                  color="primary"
+                  name="timerNeed"
+                  onChange={() => setIsTimerNeed(!isTimerNeed)}
+                  inputProps={{ 'aria-label': 'primary checkbox' }}
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <TitleAdd2>Score type:</TitleAdd2>
               </Grid>
               <Grid item xs={2}>
                 <TextField
-                  id="time"
-                  type="time"
-                  defaultValue={roundTime}
-                  onChange={(e) => setRoundTime(e.target.value)}
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                  inputProps={{
-                    step: 10, // 5 min
-                  }}
+                  error={isScoreTypeError}
+                  id="setting-scrore-type"
+                  variant="outlined"
+                  defaultValue={scoreType}
+                  onChange={(e) => handleChangeScoreType(e.target.value)}
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <TitleAdd2>Score type (Short):</TitleAdd2>
+              </Grid>
+              <Grid item xs={2}>
+                <TextField
+                  error={isScoreTypeShortError}
+                  id="setting-scrore-type"
+                  variant="outlined"
+                  defaultValue={scoreTypeShort}
+                  onChange={(e) => handleChangeScoreTypeShort(e.target.value)}
                 />
               </Grid>
             </Grid>
-          </Collapse>
-        </Container>
+            <Collapse in={isTimerNeed} timeout={1000}>
+              <Grid className="setting-grid mt-10" container spacing={3}>
+                <Grid item xs={10}>
+                  <TitleAdd2>Round time:</TitleAdd2>
+                </Grid>
+                <Grid item xs={2}>
+                  <TextField
+                    id="time"
+                    type="time"
+                    defaultValue={roundTime}
+                    onChange={(e) => setRoundTime(e.target.value)}
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                    inputProps={{
+                      step: 10, // 5 min
+                    }}
+                  />
+                </Grid>
+              </Grid>
+            </Collapse>
+          </Container>
+        )}
 
         {/******************** Add Cards Section ********************/}
-        <Container className="add-cards section" component="section">
-          <TitleAdd1 className="label-add-cards text-center">Add card values:</TitleAdd1>
-          <Box className="cards-wrapper justify-content-start mb-20">
-            {deck2.map((el, key) => (
-              <Card
-                propCardValue={el.toString()}
-                shortScoreType={scoreTypeShort}
-                allowEdit={true}
-                key={key}
-              />
-            ))}
-            <AddCard />
-          </Box>
-        </Container>
+        {isMaster && (
+          <Container className="add-cards section" component="section">
+            <TitleAdd1 className="label-add-cards text-center">
+              Add card values:
+            </TitleAdd1>
+            <Box className="cards-wrapper justify-content-start mb-20">
+              {deck2.map((el, key) => (
+                <Card
+                  propCardValue={el.toString()}
+                  shortScoreType={scoreTypeShort}
+                  allowEdit={true}
+                  key={key}
+                />
+              ))}
+              <AddCard />
+            </Box>
+          </Container>
+        )}
       </Container>
     </Box>
   );

--- a/src/Pages/Main-page/Main-page.tsx
+++ b/src/Pages/Main-page/Main-page.tsx
@@ -1,6 +1,7 @@
 import './Main-page.scss';
 
 import { TextField } from '@material-ui/core';
+import { useSnackbar } from 'notistack';
 import { FC, useContext, useEffect, useState } from 'react';
 import React from 'react';
 
@@ -12,6 +13,7 @@ const MainPage: FC = () => {
   const socket = useContext(SocketContext);
   const appState = useContext(AppContext);
   const [roomId, setRoomId] = useState('');
+  const { enqueueSnackbar } = useSnackbar();
 
   useEffect(() => {
     socket?.on('users', (users) => {
@@ -19,6 +21,9 @@ const MainPage: FC = () => {
     });
     socket?.on('issues', (issues) => {
       appState?.setIssues(issues);
+    });
+    socket?.on('notification', ({ description }) => {
+      enqueueSnackbar(description, { variant: 'info' });
     });
   });
 


### PR DESCRIPTION
1. Разделил содержимое страницы лобби для мастера и юзера
2. Данные на пользователей теперь приходят только с сервера (чтобы увидеть много юзеров нужно отрыть много вкладок с приложением и подключиться к комнате).
3. Куча мелких доработок: спинер при загрузке изображения, сообщения о подключении/отключении пользователей, сообщения об ошибках. 